### PR TITLE
Escape YAML keys containing double quotes

### DIFF
--- a/Build.fsproj
+++ b/Build.fsproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Octokit" Version="7.0.1" />
     <PackageReference Include="PulumiSchema" Version="1.2.0" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
+    <PackageReference Include="System.Text.Json" Version="8.0.3" />
   </ItemGroup>
 
 </Project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Escape YAML keys containing double quotes (https://github.com/pulumi/pulumi-converter-kubernetes/pull/15)
+
 ## 0.2.2 (March 12, 2024)
 
 - Update CI build machines to use MacOS to enable signing MacOS binary releases (https://github.com/pulumi/pulumi-converter-kubernetes/pull/12)

--- a/src/Converter/Printer.fs
+++ b/src/Converter/Printer.fs
@@ -2,6 +2,7 @@ module Converter.Printer
 
 open System
 open System.Text
+open System.Text.Json
 open Converter.PulumiTypes
 
 let rec print (expression: PulumiSyntax) (indentSize: int) (builder: StringBuilder) =
@@ -67,7 +68,8 @@ let rec print (expression: PulumiSyntax) (indentSize: int) (builder: StringBuild
                 if Seq.forall Char.IsLetterOrDigit keyText then
                     append keyText
                 else
-                    append $"\"{keyText}\""
+                    let jsonEncoded = JsonSerializer.Serialize(keyText)
+                    append jsonEncoded
             | _ ->
                 print key indentSize builder
             append " = "


### PR DESCRIPTION
Adds a failing unit test and changes our handling for complex keys to fully JSON-escape them instead of just wrapping in quotes. This has the effect of encoding `"` as a unicode code point.

This came up in the context of managed fields which are ignored during import, but if this does come up in a situation where the key isn't ignored (e.g. on an annotation) it will be correctly recovered by k8s ([example](https://go.dev/play/p/xsnandK_X6a)).

Fixes https://github.com/pulumi/pulumi-converter-kubernetes/issues/14.